### PR TITLE
Upgrade to zig 0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.10.1
+          version: master
       - run: zig build test
   lint:
     runs-on: ubuntu-latest
@@ -29,5 +29,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.10.1
-      - run: zig fmt --check src/*.zig
+          version: master
+      - run: zig fmt --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: master
+          version: 0.11.0
       - run: zig build test
   lint:
     runs-on: ubuntu-latest
@@ -29,5 +29,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: master
+          version: 0.11.0
       - run: zig fmt --check .

--- a/src/main.zig
+++ b/src/main.zig
@@ -83,7 +83,7 @@ fn CsvReader(comptime Reader: type) type {
                 return null;
             }
 
-            for (self.current) |c, pos| {
+            for (self.current, 0..) |c, pos| {
                 // TODO inline
                 for (terminators) |ct| {
                     if (c == ct) {

--- a/test/csv_tokenizer.zig
+++ b/test/csv_tokenizer.zig
@@ -18,7 +18,7 @@ fn getTokenizer(file: std.fs.File, buffer: []u8, config: csv_mod.CsvConfig) !csv
 
 fn expectToken(comptime expected: csv_mod.CsvToken, maybe_actual: ?csv_mod.CsvToken) !void {
     if (maybe_actual) |actual| {
-        if (@enumToInt(expected) != @enumToInt(actual)) {
+        if (@intFromEnum(expected) != @intFromEnum(actual)) {
             std.log.warn("Expected {?} but is {?}\n", .{ expected, actual });
             return error.TestFailed;
         }


### PR DESCRIPTION
Hello, after my last PR got merged, zig 0.11 dropped with a significant amount of breaking changes 😅 (especially in the build system).
Here's an attempt to fix compilation and test suite. Hope it's okay with you to take a look at this.
```zig
➜  zig-csv git:(nitin/zig-0.11) zig build test --summary all
Build Summary: 6/6 steps succeeded; 10/10 tests passed
test success
└─ run csv_tests 10 passed 9ms MaxRSS:905K
   ├─ zig test csv_tests Debug native cached 63ms MaxRSS:18M
   └─ install cached
      └─ install csv cached
         └─ zig build-lib csv Debug native cached 63ms MaxRSS:18M
```
