### PR TITLE
expose the CSV module to external builders

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,7 +9,7 @@ pub fn build(b: *Builder) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    var csv_module = b.createModule(.{
+    const csv_module = b.addModule("zig-csv", .{
         .source_file = .{ .path = "src/main.zig" },
     });
 


### PR DESCRIPTION
`b.createModule` creates a private module that can only be used locally, instead using `b.addModule` adds it to the list of the builds public modules which allows it to be used with the zig package manager.